### PR TITLE
fix #8

### DIFF
--- a/app/api/exists/github_org/route.js
+++ b/app/api/exists/github_org/route.js
@@ -11,7 +11,7 @@ export async function GET(request) {
   const { searchParams } = new URL(request.url);
   const name = searchParams.get('name');
   try {
-    const response = await octokit.request(`GET /orgs/${name}`, {
+    const response = await octokit.request(`GET /users/${name}`, {
       headers: {
         'X-GitHub-Api-Version': '2022-11-28',
       },


### PR DESCRIPTION
close: #8

`GET /users/{name}` has the same attribute 'html_url' as `GET /orgs/{name}`, and `/users/{name}` supports both users and organizations, so I only changed the url.

user: https://api.github.com/users/fienestar
organization: https://api.github.com/users/vercel