### PR TITLE
Add GitHub repository star threshold

### DIFF
--- a/app/api/exists/github/route.js
+++ b/app/api/exists/github/route.js
@@ -19,12 +19,14 @@ export async function GET(request) {
     },
   );
 
-  const existsUrl = response.data.items.find(
+  const repository = response.data.items.find(
     (item) => item.name.toLowerCase() === name.toLowerCase(),
-  )?.html_url;
+  );
+
+  const enoughStars = repository?.stargazers_count > 10;
 
   return NextResponse.json({
-    exists: existsUrl !== undefined,
-    existsUrl: existsUrl,
+    exists: enoughStars,
+    existsUrl: enoughStars && repository.html_url,
   });
 }

--- a/app/api/exists/github/route.js
+++ b/app/api/exists/github/route.js
@@ -19,14 +19,18 @@ export async function GET(request) {
     },
   );
 
-  const repository = response.data.items.find(
-    (item) => item.name.toLowerCase() === name.toLowerCase(),
-  );
+  const repositories = response.data.items
+    .filter(
+      (item) =>
+        item.name.toLowerCase() === name.toLowerCase() &&
+        item.stargazers_count > 10,
+    )
+    .sort((a, b) => b.stargazers_count - a.stargazers_count);
 
-  const enoughStars = repository?.stargazers_count > 10;
+  const existsUrl = repositories[0]?.html_url;
 
   return NextResponse.json({
-    exists: enoughStars,
-    existsUrl: enoughStars && repository.html_url,
+    exists: existsUrl !== undefined,
+    existsUrl: existsUrl,
   });
 }


### PR DESCRIPTION
Sometimes the existing GitHub repo has zero activity and/or no stars, this should filter those out. 10 stars is pretty arbitrary but it feels like a good starting number.